### PR TITLE
Fix: No mappable was found error

### DIFF
--- a/seminar_01/intro.ipynb
+++ b/seminar_01/intro.ipynb
@@ -709,8 +709,8 @@
     "\n",
     "    \n",
     "print (\"resulting weights:\")\n",
-    "plt.colorbar()\n",
-    "plt.imshow(weights.eval().reshape([8,8]))"
+    "plt.imshow(weights.eval().reshape([8,8]))\n",
+    "plt.colorbar()"
    ]
   }
  ],


### PR DESCRIPTION
Fix error `RuntimeError: No mappable was found to use for colorbar creation. First define a mappable such as an image (with imshow) or a contour set (with contourf).`