### PR TITLE
Remove '\n' from names

### DIFF
--- a/seminar_06/RNN_intro.ipynb
+++ b/seminar_06/RNN_intro.ipynb
@@ -378,7 +378,8 @@
     "\n",
     "with open(\"names\") as f:\n",
     "    names = f.readlines()\n",
-    "    names = [start_token + name.lower() for name in names]"
+    "    names = [start_token + name.lower() for name in names]\n",
+    "    names = [name.strip() for name in names]"
    ]
   },
   {
@@ -389,7 +390,7 @@
    "source": [
     "print('n samples = ', len(names))\n",
     "for x in names[::1000]:\n",
-    "    print(x.strip().capitalize())"
+    "    print(x.capitalize())"
    ]
   },
   {


### PR DESCRIPTION
We need to remove '\n' from names because it's useless and even harmful for generating new names.
When we use the symbol, a token vocabulary includes it and thus a neural network may produce the following results on the first epochs: 'Yeron\nl\nisat\nte',  'Droyfm\n-xha\nnle', 'V evbanq\nxsande', which are not eligible names. Also using '\n' symbol hurts convergence of the network.